### PR TITLE
Featurebranch dwk1265 new

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Data-Observation-Toolkit-UI"]
+	path = Data-Observation-Toolkit-UI
+	url = git@github.com:datakind/Data-Observation-Toolkit-UI.git

--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ from {{ schema }}.ancview_danger_sign');
 
 ```
 
+The entity preview feature in the Appsmith UI provides a way to test the SQL statement before saving it.
+If a new entity is created through the Appsmith UI, the materialization and schema definition will be added automatically,
+so the above example would be:
+```select * from {{ schema }}.ancview_danger_sign');```
+Click the "Preview Entity" button for the table on the right side of the screen to update and show the view that will be saved for this entity with the next DOT run.
+
+```postgres-sql
+
 All entities use Jinja macro statements - the parts between `{ ... }` - which the DOT uses to create the entity 
 materialized views in the correct database location. Use the above format for any new entities you create.
 
@@ -622,6 +630,11 @@ WHERE pg_stat_activity.datname = 'dot_db' AND pid <> pg_backend_pid();`
 - Login: postgres
 - Password: *Whatever you used when building the DOT docker environment*
 - Port: 5432
+
+14. Run first data import
+After configuring the first project and entity categories and before creating the first entity for the new project, it is recommended to run
+the DAG "first_synchronization" to import the data from the source database into the DOT database.
+If no data is present, the entity preview in Appsmith will not work.
 
 See section below for how to run DOT
 

--- a/docker/airflow/dags/first_synchronization.py
+++ b/docker/airflow/dags/first_synchronization.py
@@ -1,0 +1,87 @@
+"""
+This is a DAG to populate the DOT database with data from the source database.
+It has to be run manually the first time once the project has been set up, so that
+the entity_preview works
+
+The DAG loops through a list of Postgres objects (tables/views) in the data source
+       database and copy them to the DOT database
+"""
+import json
+from os import system
+from datetime import datetime
+import pandas as pd
+from airflow.models import DAG  # pylint: disable=import-error
+from airflow.operators.python import PythonOperator  # pylint: disable=import-error
+from airflow.operators.bash_operator import BashOperator  # pylint: disable=import-error
+from airflow.hooks.postgres_hook import PostgresHook  # pylint: disable=import-error
+from airflow.hooks.base import BaseHook  # pylint: disable=import-error
+from airflow.models import Variable  # pylint: disable=import-error
+from sqlalchemy import create_engine
+from run_dot_project import get_object, save_object, sync_object, default_config
+
+with DAG(
+        dag_id="first_synchronization",
+        schedule_interval="@weekly",
+        start_date=datetime(year=2022, month=3, day=1),
+        catchup=False,
+) as dag:
+    config = json.loads(Variable.get("dot_config", default_var=default_config().read()))
+
+    """
+    target_conn - Airflow connection name for target connection and schema
+    """
+
+    target_conn = config["target_connid"]
+
+    af_tasks = []
+
+    for project in config["dot_projects"]:
+
+        """
+        project_id  - Project ID, as found in dot.projects table
+        objects_to_sync - List of objects to sync, each one with definition
+            of unique field and date field
+        earliest_date_to_sync - Only sync data after this date for project
+        source_conn - Airflow connection to define where source data is
+        source_db   - Source database name
+        """
+        project_id = project["project_id"]
+        objects_to_sync = project["objects"]
+        earliest_date_to_sync = project["earliest_date_to_sync"]
+        source_conn = project["source_connid"]
+
+        # Sync data and link to dot.
+        for i in range(len(objects_to_sync)):
+
+            object_name = objects_to_sync[i]["object"]
+            if "date_field" in objects_to_sync[i] and objects_to_sync[i]["date_field"] != "":
+                date_field = objects_to_sync[i]["date_field"]
+            else:
+                date_field = None
+            id_field = objects_to_sync[i]["id_field"]
+            columns_to_exclude = (
+                objects_to_sync[i]["columns_to_exclude"]
+                if "columns_to_exclude" in objects_to_sync[i]
+                else []
+            )
+
+            # Get the data from a object in Postgres and copy to target DB
+            af_tasks.append(
+                PythonOperator(
+                    task_id=f"sync_object_{project_id}_{object_name}",
+                    python_callable=sync_object,
+                    op_kwargs={
+                        "object_name_in": object_name,
+                        "earliest_date_to_sync": earliest_date_to_sync,
+                        "date_field": date_field,
+                        "source_conn_in": source_conn,
+                        "target_conn_in": target_conn,
+                        "columns_to_exclude": columns_to_exclude,
+                    },
+                    dag=dag,
+                )
+            )
+
+    for i in range(len(af_tasks)):
+        if i > 0:
+            af_tasks[i - 1] >> af_tasks[i]

--- a/docker/docker-compose-with-airflow.yml
+++ b/docker/docker-compose-with-airflow.yml
@@ -113,6 +113,14 @@ services:
   #  container_name: superset
 
   # ================================== Web App ===============================
+  appsmith:
+    image: index.docker.io/appsmith/appsmith-ce
+    container_name: appsmith
+    ports:
+      - "82:80"
+      - "446:443"
+    volumes:
+      - ./appsmith/stacks:/appsmith-stacks
   #dot-webapp-server:
   #  build:
   #      context: ..


### PR DESCRIPTION
Followed @dividor 's advice in PR 88 (will close that one) and implemented a different logic: 

The DOT backend remained exactly the same (except for an additional DAG that's needed for the entity preview to work) so we don't have to worry about failing selftests and the entity preview was created exclusively in Appsmith:

- **Adding a new entity:** User enters SQL statement and replaces schema with {{ schema }} (Tooltip in the UI and an explanation in the ReadMe) - the "insert query" in Appsmith then adds "'{{ config(materialized=''view'') }} {% set schema = <schema> %}" to the query before it's sent to the DB.

- **Editing an existing entity:** The "select query" in Appsmith retrieves the entity definition, gets rid of the Jinja stuff, replaces {{ schema }} with the actual schema name so the user can read it, and displays it. If the user changes the entity definition and saves it, the above steps apply.   

Maybe this should be handled separately, but also included the DOT-UI repo as a submodule in the DOT repo, so that developing the UI becomes a bit easier.  