### PR TITLE
Update Python version in Container and Upgrade Airflow to later version to resolve dependency issue 

### DIFF
--- a/docker/docker-compose-with-airflow.yml
+++ b/docker/docker-compose-with-airflow.yml
@@ -53,7 +53,7 @@ x-airflow-common:
     AIRFLOW__CELERY__BROKER_URL: redis://:@redis:6379/0
     AIRFLOW__CORE__FERNET_KEY: ''
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
-    AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
+    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
     AIRFLOW__CORE__ENABLE_XCOM_PICKLING: 'true'
     PYTHON_BASE_IMAGE: "python:3.8.9-slim-buster"
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -89,6 +89,15 @@ services:
       volumes:
           - .:/db_dumps
           - ../db/dot:/docker-entrypoint-initdb.d
+
+  appsmith:
+    image: index.docker.io/appsmith/appsmith-ce
+    container_name: appsmith
+    ports:
+      - "82:80"
+      - "446:443"
+    volumes:
+      - ./appsmith/stacks:/appsmith-stacks
 
   # Not needed here, because we deploy DOT to airflow worker
   #dot:

--- a/docker/docker-compose-with-airflow.yml
+++ b/docker/docker-compose-with-airflow.yml
@@ -44,7 +44,7 @@ version: '2.1'
 
 x-airflow-common:
   &airflow-common
-  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.2.4}
+  image: ${AIRFLOW_IMAGE_NAME:-apache/airflow:2.7.3-python3.8}
   environment:
     &airflow-common-env
     AIRFLOW__CORE__EXECUTOR: CeleryExecutor
@@ -55,10 +55,9 @@ x-airflow-common:
     AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION: 'true'
     AIRFLOW__CORE__LOAD_EXAMPLES: 'true'
     AIRFLOW__CORE__ENABLE_XCOM_PICKLING: 'true'
-    PYTHON_BASE_IMAGE: "python:3:8-slim-buster"
+    PYTHON_BASE_IMAGE: "python:3.8.9-slim-buster"
     POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     SSH_AUTH_SOCK: /ssh-agent
-    AIRFLOW__CORE__LOAD_EXAMPLES: 'false'
   volumes:
     - ./airflow/dags:/opt/airflow/dags
     - airflow-logs-volume:/opt/airflow/logs


### PR DESCRIPTION
Fixes #
I noticed that the Python version in the container was Python 3.6. This caused dependency issues for some packages that require a more recent Python version. I also upgraded Airflow version from 2.2.4 to 2.7.3.

## Proposed Changes

- Upgrade airflow version from older 2.2.4 to 2.7.3 
- Update the container configuration to specify Python 3.8.9 (or another supported version) in the image.
- Verifify compatibility of existing dependencies with the new Python version.