### PR TITLE
fix: drop views instead of tables in Airflow test-schema cleanup

### DIFF
--- a/docker/airflow/dags/run_dot_project.py
+++ b/docker/airflow/dags/run_dot_project.py
@@ -297,7 +297,7 @@ def drop_tables_in_dot_tests_schema(target_conn_in, schema_to_drop_from):
                  f"BEGIN " \
                  f"FOR r IN (SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema()) " \
                  f"LOOP	" \
-                 f"EXECUTE 'DROP TABLE IF EXISTS ' || QUOTE_IDENT(r.table_name) || ' CASCADE'; " \
+                 f"EXECUTE 'DROP VIEW IF EXISTS ' || QUOTE_IDENT(r.table_name) || ' CASCADE'; " \
                  f"END LOOP; " \
                  f"END $$; "
         cur.execute(query1)

--- a/docker/airflow/dags/run_dot_project.py
+++ b/docker/airflow/dags/run_dot_project.py
@@ -271,37 +271,62 @@ def sync_object(
 
 def drop_tables_in_dot_tests_schema(target_conn_in, schema_to_drop_from):
     """
-    We are syncing new data where new columns and columns types might change.
-    Postgres will prevent ALTER TABLE if any views exist, so we will drop all tables in the dot test schema.
-    These will be recreated in the dot run.
-    This assumes the dot tests schema is dot_data_tests (defined as variable "schema_to_drop_from").
+    Clear the DOT tests schema before syncing source data.
+
+    New columns / column types can change on sync. Postgres blocks ALTER TABLE
+    while dependent views exist, so this drops views first, then any leftover
+    base tables. dbt recreates the views on the next DOT run.
 
     Input
     -----
     target_conn_in: Target database
-    schema_to_drop_from: Schema to, err, drop
+    schema_to_drop_from: Schema to clear (e.g. data_dot_data_public_tests)
 
     Action
     ------
-    1) Select schema that holds the tables which will be dropped
-    2) All tables of the selected schema are dropped from the dot_db database.
+    1) Set search_path to the tests schema
+    2) DROP VIEW for every view in that schema
+    3) DROP TABLE for every BASE TABLE in that schema
     """
 
     with PostgresHook(
             postgres_conn_id=target_conn_in, schema=target_conn_in
     ).get_conn() as conn:
         cur = conn.cursor()
-        query1 = f"SET search_path TO {schema_to_drop_from}"
-        query2 = f"DO $$ DECLARE " \
-                 f"r RECORD; " \
-                 f"BEGIN " \
-                 f"FOR r IN (SELECT table_name FROM information_schema.tables WHERE table_schema = current_schema()) " \
-                 f"LOOP	" \
-                 f"EXECUTE 'DROP VIEW IF EXISTS ' || QUOTE_IDENT(r.table_name) || ' CASCADE'; " \
-                 f"END LOOP; " \
-                 f"END $$; "
-        cur.execute(query1)
-        cur.execute(query2)
+        cur.execute(f"SET search_path TO {schema_to_drop_from}")
+        # information_schema.tables includes both views and base tables; use
+        # the matching DROP statement for each object type.
+        cur.execute(
+            """
+            DO $$
+            DECLARE
+                r RECORD;
+            BEGIN
+                FOR r IN (
+                    SELECT table_name
+                    FROM information_schema.views
+                    WHERE table_schema = current_schema()
+                )
+                LOOP
+                    EXECUTE 'DROP VIEW IF EXISTS '
+                        || quote_ident(r.table_name)
+                        || ' CASCADE';
+                END LOOP;
+
+                FOR r IN (
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = current_schema()
+                      AND table_type = 'BASE TABLE'
+                )
+                LOOP
+                    EXECUTE 'DROP TABLE IF EXISTS '
+                        || quote_ident(r.table_name)
+                        || ' CASCADE';
+                END LOOP;
+            END $$;
+            """
+        )
 
 def run_dot_app(project_id_in):
     """


### PR DESCRIPTION
## Description
### Incorrect object type in Airflow test-schema cleanup
Before syncing new source data, Airflow clears the DOT tests schema via `drop_tables_in_dot_tests_schema`. That function previously issued `DROP TABLE IF EXISTS ... CASCADE` for every object returned by `information_schema.tables`.
Because the tests schema primarily stores dbt-generated *views* rather than tables, the cleanup failed to remove them. PostgreSQL then blocked later `ALTER TABLE` operations when column types changed during the data sync, causing the pipeline to fail.

## Resolution
- Replaced the naive `DROP TABLE` loop in `docker/airflow/dags/run_dot_project.py` with a two-step PL/pgSQL block.
- The script now explicitly queries `information_schema.views` to execute `DROP VIEW IF EXISTS ... CASCADE`.
- It then queries `information_schema.tables` (filtering for `table_type = 'BASE TABLE'`) to execute `DROP TABLE IF EXISTS ... CASCADE`.
- This ensures Airflow successfully clears the dbt test schema of all object types so data syncs can proceed without `ALTER TABLE` locks.

In the Technical Documentation, this is addressed in **Section 5**.

## Asana Task
<!-- Paste Asana Task URL. Optional for release-please packaging and branch sync. -->

## Deployment Readiness\*

### Testing

Describe or check:

- [ ] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [x]  No special deployment steps required

### Rollback Plan

Describe or check:

- [x]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217234948438341