### PR TITLE
Normalize bare entity IDs in test parameter preparation

### DIFF
--- a/dot/self_tests/unit/test_entity_id_normalize.py
+++ b/dot/self_tests/unit/test_entity_id_normalize.py
@@ -1,5 +1,8 @@
 """Tests for bare entity_id normalization in test_parameters."""
 
+# Test method names already describe behavior; keep assertions uncluttered.
+# pylint: disable=missing-function-docstring
+
 from utils.configuration_utils import (
     prepare_test_parameters,
     to_bare_entity_id,
@@ -39,10 +42,7 @@ class TestToDbtFormats:
     """Wrap bare/legacy values into DBT artifact forms."""
 
     def test_to_dbt_ref_from_bare(self):
-        assert (
-            to_dbt_ref("all_airports_data")
-            == "ref('dot_model__all_airports_data')"
-        )
+        assert to_dbt_ref("all_airports_data") == "ref('dot_model__all_airports_data')"
 
     def test_to_dbt_ref_from_legacy_ref(self):
         assert (

--- a/dot/self_tests/unit/test_entity_id_normalize.py
+++ b/dot/self_tests/unit/test_entity_id_normalize.py
@@ -1,0 +1,117 @@
+"""Tests for bare entity_id normalization in test_parameters."""
+
+from utils.configuration_utils import (
+    prepare_test_parameters,
+    to_bare_entity_id,
+    to_dbt_ref,
+    to_dbt_table,
+)
+
+
+class TestToBareEntityId:
+    """to_bare_entity_id accepts bare, prefixed, and ref() forms."""
+
+    def test_bare_id(self):
+        assert to_bare_entity_id("all_airports_data") == "all_airports_data"
+
+    def test_prefixed_table(self):
+        assert to_bare_entity_id("dot_model__all_airports_data") == "all_airports_data"
+
+    def test_dbt_ref_single_quotes(self):
+        assert (
+            to_bare_entity_id("ref('dot_model__all_airports_data')")
+            == "all_airports_data"
+        )
+
+    def test_dbt_ref_double_quotes(self):
+        assert (
+            to_bare_entity_id('ref("dot_model__all_airports_data")')
+            == "all_airports_data"
+        )
+
+    def test_empty_and_none(self):
+        assert to_bare_entity_id(None) is None
+        assert to_bare_entity_id("") is None
+        assert to_bare_entity_id("   ") is None
+
+
+class TestToDbtFormats:
+    """Wrap bare/legacy values into DBT artifact forms."""
+
+    def test_to_dbt_ref_from_bare(self):
+        assert (
+            to_dbt_ref("all_airports_data")
+            == "ref('dot_model__all_airports_data')"
+        )
+
+    def test_to_dbt_ref_from_legacy_ref(self):
+        assert (
+            to_dbt_ref("ref('dot_model__all_airports_data')")
+            == "ref('dot_model__all_airports_data')"
+        )
+
+    def test_to_dbt_table_from_bare(self):
+        assert to_dbt_table("all_flight_data") == "dot_model__all_flight_data"
+
+    def test_to_dbt_table_from_prefixed(self):
+        assert (
+            to_dbt_table("dot_model__all_flight_data") == "dot_model__all_flight_data"
+        )
+
+
+class TestPrepareTestParameters:
+    """prepare_test_parameters adapts keys and entity formats per test type."""
+
+    def test_relationships_bare_to(self):
+        result = prepare_test_parameters(
+            "relationships",
+            {"to": "all_airports_data", "field": "airport", "name": "x"},
+        )
+        assert result["to"] == "ref('dot_model__all_airports_data')"
+        assert result["field"] == "airport"
+
+    def test_relationships_legacy_ref_to(self):
+        result = prepare_test_parameters(
+            "relationships",
+            {
+                "to": "ref('dot_model__all_airports_data')",
+                "field": "airport",
+            },
+        )
+        assert result["to"] == "ref('dot_model__all_airports_data')"
+
+    def test_relationships_reference_alias(self):
+        result = prepare_test_parameters(
+            "relationships",
+            {"reference": "ancview_pregnancy", "field": "uuid"},
+        )
+        assert "reference" not in result
+        assert result["to"] == "ref('dot_model__ancview_pregnancy')"
+
+    def test_expect_similar_means_bare_data_table(self):
+        result = prepare_test_parameters(
+            "expect_similar_means_across_reporters",
+            {
+                "key": "airline",
+                "data_table": "all_flight_data",
+                "target_table": "airlines_data",
+            },
+        )
+        assert result["data_table"] == "dot_model__all_flight_data"
+        assert result["target_table"] == "dot_model__airlines_data"
+
+    def test_expect_similar_means_form_name_alias(self):
+        result = prepare_test_parameters(
+            "expect_similar_means_across_reporters",
+            {"form_name": "iccmview_assessment", "key": "reported_by"},
+        )
+        assert "form_name" not in result
+        assert result["data_table"] == "dot_model__iccmview_assessment"
+
+    def test_other_test_type_unchanged(self):
+        params = {"values": ["a", "b"]}
+        assert prepare_test_parameters("accepted_values", params) == params
+
+    def test_non_dict_passthrough(self):
+        assert prepare_test_parameters("relationships", None) is None
+        assert prepare_test_parameters("relationships", "") == ""

--- a/dot/utils/configuration_management.py
+++ b/dot/utils/configuration_management.py
@@ -21,7 +21,8 @@ from utils.configuration_utils import (
     GE_GREAT_EXPECTATIONS_FINAL_FILENAME,
     GE_CONFIG_VARIABLES_FINAL_FILENAME,
     load_config_file,
-    DBT_MODELNAME_PREFIX
+    DBT_MODELNAME_PREFIX,
+    prepare_test_parameters,
 )
 from utils.dbt import create_core_entities
 
@@ -330,7 +331,9 @@ def generate_tests_from_db(project_id, logger=logging.Logger):
             column_name = row["column_name"]
             description = row["description"]
             test_type = row["test_type"]
-            test_parameters = row["test_parameters"]
+            test_parameters = prepare_test_parameters(
+                test_type, row["test_parameters"]
+            )
             # if test_parameters != None:
             #    test_parameters = "| ".join([f"{k}={test_parameters[k]}" for k in test_parameters])
             # else:
@@ -433,7 +436,10 @@ def generate_tests_from_db(project_id, logger=logging.Logger):
                 # "kwargs": add_ge_schema_parameters(
                 #    json.loads(row["test_parameters"]), project_id
                 # ),
-                "kwargs": add_ge_schema_parameters(row["test_parameters"], project_id),
+                "kwargs": add_ge_schema_parameters(
+                    prepare_test_parameters(row["test_type"], row["test_parameters"]),
+                    project_id,
+                ),
                 "meta": {},
             }
 

--- a/dot/utils/configuration_utils.py
+++ b/dot/utils/configuration_utils.py
@@ -20,7 +20,79 @@ GE_CONFIG_VARIABLES_FINAL_FILENAME = (
 )
 DBT_MODELNAME_PREFIX = "dot_model__"
 
+# Matches ref('dot_model__entity') or ref("dot_model__entity")
+_DBT_REF_PATTERN = re.compile(
+    r"""^ref\(\s*['"]""" + re.escape(DBT_MODELNAME_PREFIX) + r"""([^'"]+)['"]\s*\)$"""
+)
+
 DBT_PROJECT_SEPARATOR = "/"
+
+
+def to_bare_entity_id(value) -> Optional[str]:
+    """
+    Normalize a stored entity reference to a bare entity_id.
+
+    Accepts bare ids, `dot_model__{id}`, or `ref('dot_model__{id}')`.
+    Returns None for empty/non-string values.
+    """
+    if value is None or not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+
+    ref_match = _DBT_REF_PATTERN.match(value)
+    if ref_match:
+        return ref_match.group(1)
+
+    if value.startswith(DBT_MODELNAME_PREFIX):
+        return value[len(DBT_MODELNAME_PREFIX) :]
+
+    return value
+
+
+def to_dbt_ref(value) -> Optional[str]:
+    """Convert an entity reference to `ref('dot_model__{entity_id}')`."""
+    entity_id = to_bare_entity_id(value)
+    if entity_id is None:
+        return value if isinstance(value, str) else value
+    return f"ref('{DBT_MODELNAME_PREFIX}{entity_id}')"
+
+
+def to_dbt_table(value) -> Optional[str]:
+    """Convert an entity reference to a physical `dot_model__{entity_id}` table name."""
+    entity_id = to_bare_entity_id(value)
+    if entity_id is None:
+        return value if isinstance(value, str) else value
+    return f"{DBT_MODELNAME_PREFIX}{entity_id}"
+
+
+def prepare_test_parameters(test_type: str, params) -> dict:
+    """
+    Adapt stored test_parameters for DBT/GE artifact generation.
+
+    Stores may use bare entity_ids; legacy rows may still use ref()/dot_model__
+    prefixes. Also aliases legacy keys (reference→to, form_name→data_table).
+    """
+    if params in ("", None, "null") or not isinstance(params, dict):
+        return params
+
+    prepared = dict(params)
+
+    if test_type == "relationships":
+        if "to" not in prepared and "reference" in prepared:
+            prepared["to"] = prepared.pop("reference")
+        if "to" in prepared and prepared["to"] not in ("", None):
+            prepared["to"] = to_dbt_ref(prepared["to"])
+
+    elif test_type == "expect_similar_means_across_reporters":
+        if "data_table" not in prepared and "form_name" in prepared:
+            prepared["data_table"] = prepared.pop("form_name")
+        for key in ("data_table", "target_table"):
+            if key in prepared and prepared[key] not in ("", None):
+                prepared[key] = to_dbt_table(prepared[key])
+
+    return prepared
 
 
 def _get_filename_safely(path: str) -> str:


### PR DESCRIPTION
## Description
This PR addresses the entity identifier and parameter normalization issues described in the technical documentation .

### Hardcoded Execution Artifacts in Test Parameters
Previously, test parameters stored in the database required users to hardcode internal execution prefixes (e.g., `dot_model__`) or dbt macro syntax (e.g., `ref('dot_model__...')`). This leaked DOT's internal execution implementation details into the user-facing configuration, making the test metadata brittle and domain-specific.

## Resolution
- **Bare Entity ID Normalization:** Introduced `to_bare_entity_id`, `to_dbt_ref`, and `to_dbt_table` in `utils/configuration_utils.py`. This allows the database to store clean, domain-neutral entity strings (e.g., `all_airports_data`).
- **Dynamic Artifact Generation:** Updated `generate_tests_from_db` to pass parameters through a new `prepare_test_parameters` function. This dynamically wraps bare entity IDs into the correct `dbt` or `Great Expectations` syntax at runtime.
- **Backward Compatibility & Aliasing:** The normalization layer safely parses legacy `ref()` strings and translates deprecated parameter keys (e.g., `reference` to `to`, `form_name` to `data_table`) to ensure older project configurations do not break.
- **Unit Coverage:** Added `test_entity_id_normalize.py` to assert expected behavior across bare IDs, prefixed tables, quoted dbt references, and legacy parameter aliases.

In the Technical Documentation, this is addressed in **Section 6**.

## Asana Task
<!-- Paste Asana Task URL. Optional for release-please packaging and branch sync. -->

## Deployment Readiness\*

### Testing

Describe or check:

- [x] Created or updated unit, feature, and/or integration tests  
- [x] Typical manual testing in the local env browser, dev pipeline, etc.

### Deployment Notes

Describe or check:

- [ ]  No special deployment steps required

### Rollback Plan

Describe or check:

- [ ]  Standard revert is sufficient (`git revert`)

## Reviewer Guidance / Questions\*

## Screenshots / Testing Evidence\*

## SOC 2 Change Management Checklist

- [x] **None of the below are true in this code**  
- [ ] New roles/permissions are introduced without review and approval by the product manager  
- [ ] Hardcoded credentials, secrets, or API keys are present in this code  
- [ ] Secrets are being managed outside of the approved secrets management process (e.g., GitHub Secrets, environment variables)  
- [ ] PII or sensitive data handling is introduced or changed without being reviewed against our data classification policy  
- [ ] Sensitive data is written to logs  
- [ ] Input validation and sanitization is missing  
- [ ] An unnecessary attack surface has been introduced (e.g., unused endpoints, open ports, debug modes left enabled)  
- [ ] Common vulnerabilities have been introduced in the code (inc. any dependencies added or updated)  
- [ ] No review for common vulnerabilities has been conducted   
- [ ] Not tested in a non-production environment  
- [ ] Breaking changes to existing APIs or integrations with downstream consumers being notified  
- [ ] Performance impact has not been considered or acceptable  
- [ ] Appropriate audit logging is missing for any security-relevant actions introduced by this change  
- [ ] Log entries contain sensitive or PII data  
- [ ] All existing tests do not pass locally (`./vendor/bin/pest`)

Provide justification if you are submitting a PR with any boxes checked other than the first.

---

Reminder for Reviewers: By approving this PR you are confirming that you have reviewed the code for correctness, security, and compliance with our engineering and SOC 2 standards. Do not approve PRs where SOC 2 checklist items are checked without documented justification.

\*Optional

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217234948438344